### PR TITLE
Indexing without sharing

### DIFF
--- a/lmcache/experimental/cache_engine.py
+++ b/lmcache/experimental/cache_engine.py
@@ -102,7 +102,7 @@ class LMCacheEngine:
                 config, metadata, self.memory_allocator, self.lmcache_worker,
                 self.lookup_server)  # type: ignore[assignment]
 
-        if self.enable_p2p:
+        if self.enable_p2p and False:
             self.distributed_loop = asyncio.get_event_loop()
             assert self.lookup_server is not None
             assert isinstance(self.storage_manager, StorageManager)
@@ -300,7 +300,7 @@ class LMCacheEngine:
             memory_obj = self.storage_manager.get(key)
 
             if memory_obj is None:
-                if self.enable_p2p:
+                if self.enable_p2p and False:
                     future_memory_obj = asyncio.run_coroutine_threadsafe(
                         self.distributed_server.issue_get(key),
                         self.distributed_loop)
@@ -390,7 +390,7 @@ class LMCacheEngine:
     def close(self) -> None:
         """Close the cache engine and free all the resources"""
 
-        if self.enable_p2p:
+        if self.enable_p2p and False:
             self.distributed_server.close()
 
         if self.lmcache_worker is not None:

--- a/lmcache/experimental/lookup_server/redis_server.py
+++ b/lmcache/experimental/lookup_server/redis_server.py
@@ -64,6 +64,8 @@ class RedisLookupServer(LookupServerInterface):
         Perform batched remove in the lookup server.
         """
         logger.debug("Call to batched remove in lookup server")
+        if not keys:
+            return
         # TODO(Jiayi): We might need to cache the `str_keys` for performance.
         str_keys = [key.to_string() for key in keys]
         self.connection.delete(*str_keys)


### PR DESCRIPTION
The purpose of this PR is to enable kv-cache-aware-routing with LMCache.
All cache entries stored in LMCache will be written to a RedisLookupServer.
This is accomplished by using the enable_p2p feature in LMCache.
For now, we disable the actual data transfer between peers (which is actually broken in vllm v1).